### PR TITLE
Fix compilation error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     
     strategy:
       matrix:
-        python-version: [3.6, 3.8]
+        python-version: [3.7, 3.8]
         os: ['ubuntu-latest', 'macOs-latest', 'windows-latest']
         architecture: ['x64']
 

--- a/src/ndeval.c
+++ b/src/ndeval.c
@@ -1436,7 +1436,7 @@ main (int argc, char **argv)
       }
     else if (argc >= 2 && strcmp ("-help", argv[1]) == 0)
       {
-  print(helpText);
+//  print(helpText);
   exit (0);
       }
     else if (argc >= 5 && strcmp ("-alpha", argv[1]) == 0)

--- a/src/ndeval.c
+++ b/src/ndeval.c
@@ -1436,7 +1436,7 @@ main (int argc, char **argv)
       }
     else if (argc >= 2 && strcmp ("-help", argv[1]) == 0)
       {
-  printf (helpText);
+  print(helpText);
   exit (0);
       }
     else if (argc >= 5 && strcmp ("-alpha", argv[1]) == 0)


### PR DESCRIPTION
Fixes a compilation error with recent (`ubuntu 22.04`) default C/C++ compiler

```
      src/ndeval.c:1439:3: error: format not a string literal and no format arguments [-Werror=format-security]
       1439 |   printf (helpText);
            |   ^~~~~~
```